### PR TITLE
cleanup gcc errors, 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # Debug files
 *.dSYM/
+
+.deps/
+.dirstamp

--- a/c3dlas.c
+++ b/c3dlas.c
@@ -998,19 +998,19 @@ int boxContainsPoint2i(const AABB2i* b, const Vector2i* p) {
 }
 
 
-void boxCenter2i(const AABB2i* b, Vector2i* out) {
+void boxCenter2i(const AABB2i* b, Vector2* out) {
 	out->x = (b->max.x + b->min.x) / 2.0f;
 	out->y = (b->max.y + b->min.y) / 2.0f;
 }
 
-void boxSize2i(const AABB2i* b, Vector2i* out) {
+void boxSize2i(const AABB2i* b, Vector2* out) {
 	out->x = b->max.x - b->min.x;
 	out->y = b->max.y - b->min.y;
 }
 
 // BUG: needs some fancy math work to keep everything tight. integers don't split nicely
 void boxQuadrant2i(const AABB2i* in, char ix, char iy, AABB2i* out) {
-	Vector2i sz, c;
+	Vector2 sz, c;
 	
 	printf("fix me: %s:%d", __FILE__, __LINE__);
 	exit(666);
@@ -1020,10 +1020,10 @@ void boxQuadrant2i(const AABB2i* in, char ix, char iy, AABB2i* out) {
 	sz.x *= .5;
 	sz.y *= .5;
 	
-	out->min.x = c.x - (ix ?    0 : sz.x);
-	out->min.y = c.y - (iy ?    0 : sz.y);
-	out->max.x = c.x + (ix ? sz.x :    0);
-	out->max.y = c.y + (iy ? sz.y :    0);
+	out->min.x = c.x - (ix ? 0.0f : sz.x);
+	out->min.y = c.y - (iy ? 0.0f : sz.y);
+	out->max.x = c.x + (ix ? sz.x : 0.0f);
+	out->max.y = c.y + (iy ? sz.y : 0.0f);
 }
 
 

--- a/c3dlas.c
+++ b/c3dlas.c
@@ -25,7 +25,7 @@ int vEqEp(Vector* a, Vector* b, float epsilon) {
 	
 	n = fabs(x * x + y * y + z * z);
 	
-	return n <= epsilon * epsilon; 
+	return n <= epsilon * epsilon;
 }
 
 
@@ -144,7 +144,7 @@ void inline vSet(float x, float y, float z, Vector* out) {
 }
 
 
-// reflects the distance from v to pivot across pivot. 
+// reflects the distance from v to pivot across pivot.
 // out, pivot, and v will form a straight line with pivot exactly in the middle.
 void vReflectAcross(Vector* v, Vector* pivot, Vector* out) {
 	Vector diff;
@@ -209,7 +209,7 @@ void vUnit2(Vector2* v, Vector2* out) {
 }
 
 
-// reflects the distance from v to pivot across pivot. 
+// reflects the distance from v to pivot across pivot.
 // out, pivot, and v will form a straight line with pivot exactly in the middle.
 void vReflectAcross2(Vector2* v, Vector2* pivot, Vector2* out) {
 	Vector2 diff;
@@ -270,7 +270,7 @@ void vMatrixMul(Vector* in, Matrix* m, Vector* out) {
 	vMatrixMulf(in->x, in->y, in->z, m, out);
 }
 
-void vMatrixMulf(float x, float y, float z, Matrix* m, Vector* out) { 
+void vMatrixMulf(float x, float y, float z, Matrix* m, Vector* out) {
 	Vector4 v;
 
 	v.x = x * m->m[0+0] + y * m->m[0+1] + z * m->m[0+2] + 1 * m->m[0+3];
@@ -292,9 +292,9 @@ void vMatrixMulf(float x, float y, float z, Matrix* m, Vector* out) {
 
 
 
-const Matrix IDENT_MATRIX = { { 1, 0, 0, 0, 
-                                0, 1, 0, 0, 
-                                0, 0, 1, 0, 
+const Matrix IDENT_MATRIX = { { 1, 0, 0, 0,
+                                0, 1, 0, 0,
+                                0, 0, 1, 0,
                                 0, 0, 0, 1 } };
 
 
@@ -302,7 +302,7 @@ void mIdent(Matrix* m) {
 	*m = IDENT_MATRIX;
 }
 
-void mCopy(Matrix* in, Matrix* out) { 
+void mCopy(Matrix* in, Matrix* out) {
 	memcpy(in->m, out->m, sizeof(out->m));
 }
 
@@ -312,10 +312,10 @@ void mFastMul(Matrix* a, Matrix* b, Matrix* out) {
 	
 	for(r = 0; r < 4; r++) {
 		for(c = 0; c < 4; c++) {
-			out->m[c + r * 4] = 
-				(a->m[r * 4 + 0] * b->m[c + 0]) + 
-				(a->m[r * 4 + 1] * b->m[c + 4]) + 
-				(a->m[r * 4 + 2] * b->m[c + 8]) + 
+			out->m[c + r * 4] =
+				(a->m[r * 4 + 0] * b->m[c + 0]) +
+				(a->m[r * 4 + 1] * b->m[c + 4]) +
+				(a->m[r * 4 + 2] * b->m[c + 8]) +
 				(a->m[r * 4 + 3] * b->m[c + 12]);
 		}
 	}
@@ -460,7 +460,7 @@ float mDeterminate(Matrix* m) {
 
 // shamelessly lifted from this SO post and modified into C, added error checking, and transposed for column major ordering:
 // http://stackoverflow.com/a/7596981
-// matrix inversions suck. maybe one day i'll lift intel's super fast SSE one instead. 
+// matrix inversions suck. maybe one day i'll lift intel's super fast SSE one instead.
 // functions returns 0 if sucessful, 1 if there is no inverse
 int mInverse(Matrix* in, Matrix* out) {
 	
@@ -538,7 +538,7 @@ void mFrustum(float left, float right, float top, float bottom, float near, floa
 
 
 // analogous to gluPerspective
-// same div/0 warnings apply. if you get an FP exception you deserve it. 
+// same div/0 warnings apply. if you get an FP exception you deserve it.
 // use a double for fov; the precision matters often.
 // https://www.opengl.org/archives/resources/faq/technical/transformations.htm
 // https://www.opengl.org/sdk/docs/man2/xhtml/gluPerspective.xml
@@ -574,7 +574,7 @@ void mOrtho(float left, float right, float top, float bottom, float near, float 
 	m.m[5] = 2 / (top - bottom);
 	m.m[10] = -2 / (far - near);
 	m.m[12] = -(right + left) / (right - left);
-	m.m[13] = -(top + bottom) / (top - bottom);		
+	m.m[13] = -(top + bottom) / (top - bottom);
 	m.m[14] = -(far + near) / (far - near);
 	m.m[15] = 1;
 	
@@ -726,7 +726,7 @@ void msRot3f(float x, float y, float z, float theta, MatrixStack* ms) { // rotat
 	mRot3f(x, y, z, theta, msGetTop(ms));
 }
 
-void msFrustum(float left, float right, float top, float bottom, float near, float far, MatrixStack* ms) { 
+void msFrustum(float left, float right, float top, float bottom, float near, float far, MatrixStack* ms) {
 	mFrustum(left, right, top, bottom, near, far, msGetTop(ms));
 }
 
@@ -899,7 +899,7 @@ int boxContainsPoint2i(const AABB2i* b, const Vector2i* p) {
 }
 
 
-void boxCenter2i(const AABB2i* b, Vector2* out) {
+void boxCenter2i(const AABB2i* b, Vector2i* out) {
 	out->x = (b->max.x + b->min.x) / 2.0f;
 	out->y = (b->max.y + b->min.y) / 2.0f;
 }
@@ -911,20 +911,20 @@ void boxSize2i(const AABB2i* b, Vector2i* out) {
 
 // BUG: needs some fancy math work to keep everything tight. integers don't split nicely
 void boxQuadrant2i(const AABB2i* in, char ix, char iy, AABB2i* out) {
-	Vector2 sz, c;
+	Vector2i sz, c;
 	
 	printf("fix me: %s:%d", __FILE__, __LINE__);
 	exit(666);
 	
-	boxCenter2(in, &c);
-	boxSize2(in, &sz);
+	boxCenter2i(in, &c);
+	boxSize2i(in, &sz);
 	sz.x *= .5;
 	sz.y *= .5;
 	
-	out->min.x = c.x - (ix ? 0.0f : sz.x);
-	out->min.y = c.y - (iy ? 0.0f : sz.y);
-	out->max.x = c.x + (ix ? sz.x : 0.0f);
-	out->max.y = c.y + (iy ? sz.y : 0.0f);
+	out->min.x = c.x - (ix ?    0 : sz.x);
+	out->min.y = c.y - (iy ?    0 : sz.y);
+	out->max.x = c.x + (ix ? sz.x :    0);
+	out->max.y = c.y + (iy ? sz.y :    0);
 }
 
 
@@ -967,13 +967,13 @@ void quadRoundInward2(const Quad2* in, Quad2i* out) {
 
 int quadIsPoint2i(const Quad2i* q) {
 	return (
-		q->v[0].x == q->v[1].x == q->v[2].x == q->v[3].x && 
+		q->v[0].x == q->v[1].x == q->v[2].x == q->v[3].x &&
 		q->v[0].y == q->v[1].y == q->v[2].y == q->v[3].y);
 }
 
 int quadIsAARect2i(const Quad2i* q) {
 	return (
-		q->v[0].x == q->v[3].x && q->v[1].x == q->v[2].x && 
+		q->v[0].x == q->v[3].x && q->v[1].x == q->v[2].x &&
 		q->v[0].y == q->v[1].y && q->v[2].y == q->v[3].y);
 }
 
@@ -989,7 +989,7 @@ void makeRay(Vector* origin, Vector* direction, Ray* out) {
 	vInverse(&out->d, &out->id);
 }
 
-// this version has no branching, but only answers yes or no. 
+// this version has no branching, but only answers yes or no.
 // algorithm explanation here. hopefully my extrapolation into 3 dimensions is correct.
 // http://tavianator.com/fast-branchless-raybounding-box-intersections/
 int boxRayIntersectFast(const AABB* b, const Ray* r) {
@@ -1090,7 +1090,7 @@ static void bsSegmentForT2(BezierSpline2* bs, float normalT, Vector2* out) {
 	out[1].y = p->c.y;
 	
 	// control 2 - this one is reflected across e2
-	vReflectAcross(&n->c, &n->e, &out[2]); 
+	vReflectAcross2(&n->c, &n->e, &out[2]);
 	
 	// end 2
 	out[3].x = n->e.x;
@@ -1110,7 +1110,7 @@ void bsEvalPoint2(BezierSpline2* bs, float normalT, Vector2* out) {
 	float localT;
 	
 	// find which spline segment the t is in
-	localT = bsNormalToLocalT2(bs, normalT, &segN);  
+	localT = bsNormalToLocalT2(bs, normalT, &segN);
 	
 	// find the local value of t
 	Vector2 cp[4];

--- a/c3dlas.c
+++ b/c3dlas.c
@@ -140,7 +140,7 @@ void  vMax(Vector* a, Vector* b, Vector* out) {
 void inline vSet(float x, float y, float z, Vector* out) {
 	out->x = x;
 	out->y = y;
-	out->z = x;
+	out->z = z;
 }
 
 
@@ -168,6 +168,26 @@ void  vTriFaceNormal(Vector* a, Vector* b, Vector* c, Vector* out) {
 
 // 2d vector stuff
 
+int vEq2(Vector2* a, Vector2* b) {
+	return vEqEp2(a, b, FLT_CMP_EPSILON);
+}
+
+int vEqEp2(Vector2* a, Vector2* b, float epsilon) {
+	float x, y, n;
+	
+	x = a->x - b->x;
+	y = a->y - b->y;
+	
+	n = fabs(x * x + y * y);
+	
+	return n <= epsilon * epsilon;
+}
+
+void vCopy2(const Vector2* src, Vector2* dst) {
+	dst->x = src->x;
+	dst->y = src->y;
+}
+
 void vSwap2(Vector2* a, Vector2* b) { // swap two vectors
 	float x, y;
 	x = a->x;
@@ -193,6 +213,20 @@ void vScale2(Vector2* v, float scalar, Vector2* out) {
 	out->y = v->y * scalar;
 }
 
+void vInverse2(Vector2* v, Vector2* out) {
+	// see vInverse for snark
+	out->x = v->x == 0.0f ? FLT_MAX : 1.0f / v->x;
+	out->y = v->y == 0.0f ? FLT_MAX : 1.0f / v->y;
+}
+
+float vMag2(Vector2* v) {
+	return sqrt((float)((v->x * v->x) + (v->y * v->y)));
+}
+
+float vDot2(Vector2* a, Vector2* b) {
+	return (float)((a->x * b->x) + (a->y * b->y));
+}
+
 void vNorm2(Vector2* v, Vector2* out) {
 	vUnit2(v, out);
 }
@@ -208,6 +242,23 @@ void vUnit2(Vector2* v, Vector2* out) {
 	out->y = v->y * n;
 }
 
+// returns the minimum values of each component
+void  vMin2(Vector2* a, Vector2* b, Vector2* out) {
+	out->x = fmin(a->x, b->x);
+	out->y = fmin(a->y, b->y);
+}
+
+// returns the maximum values of each component
+void  vMax2(Vector2* a, Vector2* b, Vector2* out) {
+	out->x = fmax(a->x, b->x);
+	out->y = fmax(a->y, b->y);
+}
+
+void inline vSet2(float x, float y, Vector2* out) {
+	out->x = x;
+	out->y = y;
+}
+
 
 // reflects the distance from v to pivot across pivot.
 // out, pivot, and v will form a straight line with pivot exactly in the middle.
@@ -216,20 +267,6 @@ void vReflectAcross2(Vector2* v, Vector2* pivot, Vector2* out) {
 	
 	vSub2(pivot, v, &diff);
 	vAdd2(pivot, &diff, out);
-}
-
-
-
-
-
-void vSwap2i(Vector2i* a, Vector2i* b) { // swap two vectors
-	int x, y;
-	x = a->x;
-	y = a->y;
-	a->x = b->x;
-	a->y = b->y;
-	b->x = x;
-	b->y = y;
 }
 
 
@@ -252,6 +289,68 @@ void vRoundToward2(const Vector2* in, const Vector2* center, Vector2i* out) {
 	if(in->y > center->y) out->y = floorf(in->y);
 	else out->y = ceilf(in->y);
 }
+
+
+
+// 2d integer vector stuff
+
+int vEq2i(Vector2i* a, Vector2i* b) {
+	return a->x == b->x && a->y == b->y;
+}
+
+void vCopy2i(const Vector2i* src, Vector2i* dst) {
+	dst->x = src->x;
+	dst->y = src->y;
+}
+
+void vSwap2i(Vector2i* a, Vector2i* b) { // swap two vectors
+	int x, y;
+	x = a->x;
+	y = a->y;
+	a->x = b->x;
+	a->y = b->y;
+	b->x = x;
+	b->y = y;
+}
+
+void vAdd2i(Vector2i* a, Vector2i* b, Vector2i* out) {
+	out->x = a->x + b->x;
+	out->y = a->y + b->y;
+}
+
+void vSub2i(Vector2i* from, Vector2i* what, Vector2i* diff) { // diff = from - what
+	diff->x = from->x - what->x;
+	diff->y = from->y - what->y;
+}
+
+void vScale2i(Vector2i* v, int scalar, Vector2i* out) {
+	out->x = v->x * scalar;
+	out->y = v->y * scalar;
+}
+
+int vDot2i(Vector2i* a, Vector2i* b) {
+	return ((a->x * b->x) + (a->y * b->y));
+}
+
+// returns the minimum values of each component
+void  vMin2i(Vector2i* a, Vector2i* b, Vector2i* out) {
+	out->x = MIN(a->x, b->x);
+	out->y = MIN(a->y, b->y);
+}
+
+// returns the maximum values of each component
+void  vMax2i(Vector2i* a, Vector2i* b, Vector2i* out) {
+	out->x = MAX(a->x, b->x);
+	out->y = MAX(a->y, b->y);
+}
+
+void inline vSet2i(int x, int y, Vector2i* out) {
+	out->x = x;
+	out->y = y;
+}
+
+
+
 
 // plane-vector operations
 

--- a/c3dlas.h
+++ b/c3dlas.h
@@ -320,8 +320,8 @@ int boxDisjoint2i(const AABB2i* a, const AABB2i* b);
 int boxOverlaps2i(const AABB2i* a, const AABB2i* b);
 int boxContainsPoint2i(const AABB2i* b, const Vector2i* p);
 
-void boxCenter2i(const AABB2i* b, Vector2i* out); // calcuates the center of the box
-void boxSize2i(const AABB2i* b, Vector2i* out); // calculates the size of the box
+void boxCenter2i(const AABB2i* b, Vector2* out); // calcuates the center of the box
+void boxSize2i(const AABB2i* b, Vector2* out); // calculates the size of the box
 void boxQuadrant2i(const AABB2i* in, char ix, char iy, AABB2i* out);
 
 // find the center of a quad

--- a/c3dlas.h
+++ b/c3dlas.h
@@ -20,6 +20,28 @@
 #define FLT_CMP_EPSILON 0.000001
 
 
+#define MAX(a,b) ({ \
+	__typeof__ (a) _a = (a); \
+	__typeof__ (b) _b = (b); \
+	_a > _b ? _a : _b; \
+})
+#define MIN(a,b) ({ \
+	__typeof__ (a) _a = (a); \
+	__typeof__ (b) _b = (b); \
+	_a < _b ? _a : _b; \
+})
+#define MAXE(a,b) ({ \
+	__typeof__ (a) _a = (a); \
+	__typeof__ (b) _b = (b); \
+	_a >= _b ? _a : _b; \
+})
+#define MINE(a,b) ({ \
+	__typeof__ (a) _a = (a); \
+	__typeof__ (b) _b = (b); \
+	_a <= _b ? _a : _b; \
+})
+
+
 typedef struct {
 	float x,y;
 } Vector2;
@@ -119,7 +141,7 @@ extern const Matrix IDENT_MATRIX;
 
 int   vEq(Vector* a, Vector* b); // safe equivalence, to FLT_CMP_EPSILON
 int   vEqEp(Vector* a, Vector* b, float epsilon); // safe equivalence, to arbitrary epsilon
-void  vCopy(const Vector* src, Vector* dst); // add two vectors
+void  vCopy(const Vector* src, Vector* dst); // copy vector values
 void  vSwap(Vector* a, Vector* b); // swap two vectors
 void  vAdd(Vector* a, Vector* b, Vector* out); // add two vectors
 void  vSub(Vector* from, Vector* what, Vector* diff); // diff = from - what
@@ -141,6 +163,49 @@ void  vSet(float x, float y, float z, Vector* out);
 // out, pivot, and v will form a straight line with pivot exactly in the middle.
 void  vReflectAcross(Vector* v, Vector* pivot, Vector* out);
 void  vTriFaceNormal(Vector* a, Vector* b, Vector* c, Vector* out); // returns a normalized face normal for the given triangle
+
+
+// 2d vector stuff, same as 3d except one less d
+int   vEq2(Vector2* a, Vector2* b); // safe equivalence, to FLT_CMP_EPSILON
+int   vEqEp2(Vector2* a, Vector2* b, float epsilon); // safe equivalence, to arbitrary epsilon
+void  vCopy2(const Vector2* src, Vector2* dst); // copy vector values
+void  vSwap2(Vector2* a, Vector2* b); // swap two vectors
+void  vAdd2(Vector2* a, Vector2* b, Vector2* out); // add two vectors
+void  vSub2(Vector2* from, Vector2* what, Vector2* diff); // diff = from - what
+void  vScale2(Vector2* v, float scalar, Vector2* out); // scalar muliplication
+void  vInverse2(Vector2* v, Vector2* out); // inverse
+float vMag2(Vector2* v); // return the magnitude
+float vDot2(Vector2* a, Vector2* b); // dot product
+void  vNorm2(Vector2* v, Vector2* out); // normalize the vector
+void  vUnit2(Vector2* v, Vector2* out); // normalise the vector, alternate name
+void  vMin2(Vector2* a, Vector2* b, Vector2* out); // returns the minimum values of each component
+void  vMax2(Vector2* a, Vector2* b, Vector2* out); // returns the maximum values of each component
+void  vSet2(float x, float y, Vector2* out);
+
+// reflects the distance from v to pivot across pivot.
+// out, pivot, and v will form a straight line with pivot exactly in the middle.
+void  vReflectAcross2(Vector2* v, Vector2* pivot, Vector2* out);
+
+// degenerate cases may not give desired results. GIGO.
+void  vRoundAway2(const Vector2* in, const Vector2* center, Vector2i* out);
+void  vRoundToward2(const Vector2* in, const Vector2* center, Vector2i* out);
+
+
+// 2d integer vector stuff
+int   vEq2i(Vector2i* a, Vector2i* b);
+void  vCopy2i(const Vector2i* src, Vector2i* dst); // copy vector values
+void  vSwap2i(Vector2i* a, Vector2i* b); // swap two vectors
+void  vAdd2i(Vector2i* a, Vector2i* b, Vector2i* out); // add two vectors
+void  vSub2i(Vector2i* from, Vector2i* what, Vector2i* diff); // diff = from - what
+void  vScale2i(Vector2i* v, int scalar, Vector2i* out); // scalar muliplication
+int   vDot2i(Vector2i* a, Vector2i* b); // dot product
+void  vMin2i(Vector2i* a, Vector2i* b, Vector2i* out); // returns the minimum values of each component
+void  vMax2i(Vector2i* a, Vector2i* b, Vector2i* out); // returns the maximum values of each component
+void  vSet2i(int x, int y, Vector2i* out);
+
+
+
+
 
 float pvDist(Plane* p, Vector* v);
 
@@ -263,25 +328,6 @@ void boxQuadrant2i(const AABB2i* in, char ix, char iy, AABB2i* out);
 void quadCenter2(const Quad2* in, Vector2* out);
 void quadRoundOutward2(const Quad2* in, Quad2i* out);
 void quadRoundInward2(const Quad2* in, Quad2i* out);
-
-// 2d vector stuff, same as 3d except one less d
-void  vSwap2(Vector2* a, Vector2* b); // swap two vectors
-void  vAdd2(Vector2* a, Vector2* b, Vector2* out); // add two vectors
-void  vSub2(Vector2* from, Vector2* what, Vector2* diff); // diff = from - what
-void  vScale2(Vector2* v, float scalar, Vector2* out); // scalar muliplication
-void  vNorm2(Vector2* v, Vector2* out); // normalize the vector
-void  vUnit2(Vector2* v, Vector2* out); // normalise the vector, alternate name
-
-// reflects the distance from v to pivot across pivot.
-// out, pivot, and v will form a straight line with pivot exactly in the middle.
-void  vReflectAcross2(Vector2* v, Vector2* pivot, Vector2* out);
-
-// degenerate cases may not give desired results. GIGO.
-void  vRoundAway2(const Vector2* in, const Vector2* center, Vector2i* out);
-void  vRoundToward2(const Vector2* in, const Vector2* center, Vector2i* out);
-
-// 2d integer vector stuff
-void  vSwap2i(Vector2i* a, Vector2i* b); // swap two vectors
 
 #endif // __c3dlas_h__
 

--- a/c3dlas.h
+++ b/c3dlas.h
@@ -123,7 +123,7 @@ void  vCopy(const Vector* src, Vector* dst); // add two vectors
 void  vSwap(Vector* a, Vector* b); // swap two vectors
 void  vAdd(Vector* a, Vector* b, Vector* out); // add two vectors
 void  vSub(Vector* from, Vector* what, Vector* diff); // diff = from - what
-void  vScale(Vector* v, float scalar, Vector* out); // scalar muliplication 
+void  vScale(Vector* v, float scalar, Vector* out); // scalar muliplication
 void  vInverse(Vector* v, Vector* out); // inverse
 float vMag(Vector* v); // return the magnitude
 float vDot(Vector* a, Vector* b); // dot product
@@ -137,9 +137,9 @@ void  vMin(Vector* a, Vector* b, Vector* out); // returns the minimum values of 
 void  vMax(Vector* a, Vector* b, Vector* out); // returns the maximum values of each component
 void  vSet(float x, float y, float z, Vector* out);
 
-// reflects the distance from v to pivot across pivot. 
+// reflects the distance from v to pivot across pivot.
 // out, pivot, and v will form a straight line with pivot exactly in the middle.
-void  vReflectAcross(Vector* v, Vector* pivot, Vector* out); 
+void  vReflectAcross(Vector* v, Vector* pivot, Vector* out);
 void  vTriFaceNormal(Vector* a, Vector* b, Vector* c, Vector* out); // returns a normalized face normal for the given triangle
 
 float pvDist(Plane* p, Vector* v);
@@ -149,7 +149,7 @@ void vMatrixMulf(float x, float y, float z, Matrix* m, Vector* out); // multiply
 
 
 void mIdent(Matrix* m); // set m to the identity matrix
-void mCopy(Matrix* in, Matrix* out); 
+void mCopy(Matrix* in, Matrix* out);
 void mFastMul(Matrix* a, Matrix* b, Matrix* out); // a and b cannot also be out. mostly internal use.
 void mMul(Matrix* a, Matrix* out); // makes a copy of out before multiplying over it
 void mTransv(Vector* v, Matrix* out); // translation
@@ -158,7 +158,7 @@ void mScalev(Vector* v, Matrix* out);
 void mScale3f(float x, float y, float z, Matrix* out);
 void mRotv(Vector* v, float theta, Matrix* out); // rotate about a vector
 void mRot3f(float x, float y, float z, float theta, Matrix* out); // rotate about a vector
-void mRotX(float theta, Matrix* out); // 
+void mRotX(float theta, Matrix* out); //
 void mRotY(float theta, Matrix* out); // rotate about axes
 void mRotZ(float theta, Matrix* out); //
 void mTranspose(Matrix* in, Matrix* out);
@@ -172,14 +172,14 @@ int mInverse(Matrix* in, Matrix* out); // returns 0 on success, 1 if there is no
 void mFrustum(float left, float right, float top, float bottom, float near, float far, Matrix* out);
 
 // analogous to gluPerspective
-// same div/0 warnings apply. if you get an FP exception you deserve it. 
+// same div/0 warnings apply. if you get an FP exception you deserve it.
 // use a double for fov; the precision matters often.
 // https://www.opengl.org/archives/resources/faq/technical/transformations.htm
 // https://www.opengl.org/sdk/docs/man2/xhtml/gluPerspective.xml
 void mPerspective(double fov, float aspect, float near, float far, Matrix* out);
 
 // orthographic projection. use this for a "2D" look.
-// same div/0 warnings. 
+// same div/0 warnings.
 void mOrtho(float left, float right, float top, float bottom, float near, float far, Matrix* out);
 
 // analgous to gluLookAt
@@ -196,7 +196,7 @@ void mPrint(Matrix* m, FILE* f);
 void msAlloc(int size, MatrixStack* ms);
 void msFree(MatrixStack* ms);
 
-int msPush(MatrixStack* ms); 
+int msPush(MatrixStack* ms);
 void msPop(MatrixStack* ms);
 Matrix* msGetTop(MatrixStack* ms);
 
@@ -204,7 +204,7 @@ void msPrintAll(MatrixStack* ms, FILE* f);
 
 // these are all wrappers around the functions listed above
 void msIdent(MatrixStack* ms); // set to the identity matrix
-void msCopy(Matrix* in, MatrixStack* ms); 
+void msCopy(Matrix* in, MatrixStack* ms);
 void msMul(Matrix* a, MatrixStack* ms); // makes a copy of out before multiplying over it
 void msTransv(Vector* v, MatrixStack* ms); // translation
 void msTrans3f(float x, float y, float z, MatrixStack* ms); // translation
@@ -219,7 +219,7 @@ void msLookAt(Vector* eye, Vector* center, Vector* up, MatrixStack* ms);
 
 
 void evalBezier(Vector* e1, Vector* e2, Vector* c1, Vector* c2, float t, Vector* out);
-void evalBezierTangent(Vector* e1, Vector* e2, Vector* c1, Vector* c2, float t, Vector* out); // tangent vector; not normalized 
+void evalBezierTangent(Vector* e1, Vector* e2, Vector* c1, Vector* c2, float t, Vector* out); // tangent vector; not normalized
 void evalBezierNorm(Vector* e1, Vector* e2, Vector* c1, Vector* c2, float t, Vector* out); // normal vector; not normalized
 float evalBezier1D(float e1, float e2, float c1, float c2, float t);
 float evalBezier1D_dt(float e1, float e2, float c1, float c2, float t); // first derivative with respect to t
@@ -255,12 +255,12 @@ int boxDisjoint2i(const AABB2i* a, const AABB2i* b);
 int boxOverlaps2i(const AABB2i* a, const AABB2i* b);
 int boxContainsPoint2i(const AABB2i* b, const Vector2i* p);
 
-void boxCenter2i(const AABB2i* b, Vector2* out); // calcuates the center of the box
+void boxCenter2i(const AABB2i* b, Vector2i* out); // calcuates the center of the box
 void boxSize2i(const AABB2i* b, Vector2i* out); // calculates the size of the box
 void boxQuadrant2i(const AABB2i* in, char ix, char iy, AABB2i* out);
 
 // find the center of a quad
-void quadCenter2(const Quad2* in, Vector2* out); 
+void quadCenter2(const Quad2* in, Vector2* out);
 void quadRoundOutward2(const Quad2* in, Quad2i* out);
 void quadRoundInward2(const Quad2* in, Quad2i* out);
 
@@ -268,17 +268,17 @@ void quadRoundInward2(const Quad2* in, Quad2i* out);
 void  vSwap2(Vector2* a, Vector2* b); // swap two vectors
 void  vAdd2(Vector2* a, Vector2* b, Vector2* out); // add two vectors
 void  vSub2(Vector2* from, Vector2* what, Vector2* diff); // diff = from - what
-void  vScale2(Vector2* v, float scalar, Vector2* out); // scalar muliplication 
+void  vScale2(Vector2* v, float scalar, Vector2* out); // scalar muliplication
 void  vNorm2(Vector2* v, Vector2* out); // normalize the vector
 void  vUnit2(Vector2* v, Vector2* out); // normalise the vector, alternate name
 
-// reflects the distance from v to pivot across pivot. 
+// reflects the distance from v to pivot across pivot.
 // out, pivot, and v will form a straight line with pivot exactly in the middle.
-void  vReflectAcross2(Vector2* v, Vector2* pivot, Vector2* out); 
+void  vReflectAcross2(Vector2* v, Vector2* pivot, Vector2* out);
 
 // degenerate cases may not give desired results. GIGO.
-void  vRoundAway2(const Vector2* in, const Vector2* center, Vector2i* out); 
-void  vRoundToward2(const Vector2* in, const Vector2* center, Vector2i* out); 
+void  vRoundAway2(const Vector2* in, const Vector2* center, Vector2i* out);
+void  vRoundToward2(const Vector2* in, const Vector2* center, Vector2i* out);
 
 // 2d integer vector stuff
 void  vSwap2i(Vector2i* a, Vector2i* b); // swap two vectors


### PR DESCRIPTION
Assuming 2i functions only use 2i parameters/variables, the only non-obvious change is converting `Vector2* out` to `Vector2i* out` in `boxCenter2i`'s signature to resolve type errors and follow the `i` part. `boxQuadrant2i` also switched to `Vector2i` variables and `i` function calls.
